### PR TITLE
use local chromeless npm module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 FROM articulate/articulate-node:8
 
-COPY ./serverless/package.json ./serverless/yarn.lock $SERVICE_ROOT/
+COPY ./package.json ./yarn.lock $SERVICE_ROOT/
+COPY ./serverless/package.json ./serverless/yarn.lock $SERVICE_ROOT/serverless/
 
 RUN yarn install --pure-lockfile
+RUN cd serverless && yarn install --pure-lockfile
 
-COPY ./serverless $SERVICE_ROOT/
+COPY ./ $SERVICE_ROOT/
+
+RUN yarn build
 
 RUN chown -R $SERVICE_USER:$SERVICE_USER $SERVICE_ROOT
 USER $SERVICE_USER
 
-CMD yarn deploy
+CMD cd serverless && yarn deploy

--- a/serverless/package.json
+++ b/serverless/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "aws4": "^1.6.0",
-    "chromeless": "^1.2.0",
+    "chromeless": "file:../",
     "cuid": "^1.3.8",
     "mqtt": "^2.11.0",
     "source-map-support": "^0.4.15"

--- a/serverless/yarn.lock
+++ b/serverless/yarn.lock
@@ -431,9 +431,20 @@ chrome-remote-interface@^0.24.2:
     commander "2.1.x"
     ws "2.0.x"
 
-chromeless@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/chromeless/-/chromeless-1.1.0.tgz#9e40221544bd289263fc87cb2ea8e46a4d2a0468"
+chromeless@^1.2.0:
+  version "1.2.0"
+  dependencies:
+    aws-sdk "^2.90.0"
+    bluebird "^3.5.0"
+    chrome-launcher "^0.4.0"
+    chrome-remote-interface "^0.24.2"
+    cuid "^1.3.8"
+    form-data "^2.1.4"
+    got "^7.1.0"
+    mqtt "^2.9.2"
+
+"chromeless@file:../":
+  version "1.2.0"
   dependencies:
     aws-sdk "^2.90.0"
     bluebird "^3.5.0"
@@ -1473,7 +1484,7 @@ mqtt-packet@^5.4.0:
     process-nextick-args "^1.0.7"
     safe-buffer "^5.1.0"
 
-mqtt@^2.11.0:
+mqtt@^2.11.0, mqtt@^2.9.2:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/mqtt/-/mqtt-2.11.0.tgz#39031df4a300532f3c64e61050dda212bf055eb0"
   dependencies:
@@ -1489,24 +1500,6 @@ mqtt@^2.11.0:
     reinterval "^1.1.0"
     split2 "^2.1.1"
     websocket-stream "^5.0.1"
-    xtend "^4.0.1"
-
-mqtt@^2.9.2:
-  version "2.9.3"
-  resolved "https://registry.yarnpkg.com/mqtt/-/mqtt-2.9.3.tgz#45c381a2c96f4c2ee2ea3a0b3c0c02ef063cd4c0"
-  dependencies:
-    commist "^1.0.0"
-    concat-stream "^1.6.0"
-    end-of-stream "^1.1.0"
-    help-me "^1.0.1"
-    inherits "^2.0.3"
-    minimist "^1.2.0"
-    mqtt-packet "^5.4.0"
-    pump "^1.0.2"
-    readable-stream "^2.3.3"
-    reinterval "^1.1.0"
-    split2 "^2.1.1"
-    websocket-stream "^5.0.0"
     xtend "^4.0.1"
 
 ms@0.7.1:
@@ -2212,17 +2205,6 @@ vise@2.x.x:
 walkdir@^0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/walkdir/-/walkdir-0.0.11.tgz#a16d025eb931bd03b52f308caed0f40fcebe9532"
-
-websocket-stream@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/websocket-stream/-/websocket-stream-5.0.0.tgz#1d1318f0576ce20a12555372108ae9418a403634"
-  dependencies:
-    duplexify "^3.2.0"
-    inherits "^2.0.1"
-    readable-stream "^2.2.0"
-    safe-buffer "^5.0.1"
-    ws "^3.0.0"
-    xtend "^4.0.0"
 
 websocket-stream@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
https://github.com/graphcool/chromeless/pull/224 was merged allowing setting an s3 key prefix via env var, but a new version of the npm module hasn't been released.  Additionally, the project is written in Typescript so it has to be transpiled to javascript before being imported (it's transpiled on publish to npm).  To get around that for now, we'll build it in the container and reference the local copy.